### PR TITLE
Add Evmos token

### DIFF
--- a/tokens/EVMOS.json
+++ b/tokens/EVMOS.json
@@ -1,0 +1,21 @@
+{
+  "coinDenom": "EVMOS",
+  "minCoinDenom": "EVMOS",
+  "imgSrc": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg",
+  "pngSrc": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.png",
+  "type": "IBC",
+  "exponent": "18",
+  "cosmosDenom": "",
+  "description": "EVMOS",
+  "name": "EVMOS",
+  "channel": "",
+  "isEnabled": true,
+  "erc20_address": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517",
+  "ibc": {
+    "sourceDenom": "aevmos",
+    "source": "Evmos"
+  },
+  "hideFromTestnet": false,
+  "coingeckoId": "evmos"
+}
+  

--- a/tokens/EVMOS.json
+++ b/tokens/EVMOS.json
@@ -18,4 +18,3 @@
   "hideFromTestnet": false,
   "coingeckoId": "evmos"
 }
-  

--- a/tokens/EVMOS.json
+++ b/tokens/EVMOS.json
@@ -10,7 +10,7 @@
   "name": "EVMOS",
   "channel": "",
   "isEnabled": true,
-  "erc20_address": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517",
+  "erc20Address": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517",
   "ibc": {
     "sourceDenom": "aevmos",
     "source": "Evmos"


### PR DESCRIPTION
This PR adds EVMOS token details (IBC and ERC20) to be used in the new permissionless Assets page