### PR TITLE
Add rest-jrpc-web3 to schema

### DIFF
--- a/schema.chain.json
+++ b/schema.chain.json
@@ -4,14 +4,22 @@
   "description": "Chain Registry via Evmos Governance",
   "type": "object",
   "properties": {
-    "required": ["gasPriceStep", "prefix", "bip44"],
+    "required": [
+      "gasPriceStep",
+      "prefix",
+      "bip44"
+    ],
     "prefix": {
       "type": "string",
       "description": "Chain prefix i.e. evmos"
     },
     "gasPriceStep": {
       "type": "object",
-      "required": ["low", "average", "high"],
+      "required": [
+        "low",
+        "average",
+        "high"
+      ],
       "properties": {
         "low": {
           "type": "string",
@@ -25,13 +33,21 @@
           "type": "string",
           "description": "Amount of gas for High"
         },
-        "required": ["low", "medium", "high"]
+        "required": [
+          "low",
+          "medium",
+          "high"
+        ]
       }
     },
     "feeMarket": {
       "type": "object",
       "description": "Only applicable to EVMOS",
-      "required": ["gas", "amount", "convert"],
+      "required": [
+        "gas",
+        "amount",
+        "convert"
+      ],
       "properties": {
         "gas": {
           "type": "string",
@@ -49,7 +65,9 @@
     },
     "bip44": {
       "type": "object",
-      "required": ["coinType"],
+      "required": [
+        "coinType"
+      ],
       "properties": {
         "coinType": {
           "type": "string",
@@ -89,10 +107,23 @@
             "description": "RPC endpoint link, usually port 1317"
           },
           "rest": {
-            "type": "string",
-            "description": "REST endpoint link"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
-
+          "jrpc": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "web3": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "currencies": {
             "type": "array",
             "items": {
@@ -115,7 +146,11 @@
           },
           "source": {
             "type": "object",
-            "required": ["sourceChannel", "destinationChannel", "jsonRPC"],
+            "required": [
+              "sourceChannel",
+              "destinationChannel",
+              "jsonRPC"
+            ],
             "properties": {
               "sourceChannel": {
                 "type": "string",
@@ -136,11 +171,17 @@
             "description": "Explorer is only necessary for EVMOS network. All other Cosmos chains do not require this array object to be filled out",
             "items": {
               "type": "object",
-              "required": ["link", "type"],
+              "required": [
+                "link",
+                "type"
+              ],
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["evm", "cosmos"],
+                  "enum": [
+                    "evm",
+                    "cosmos"
+                  ],
                   "description": "Add the correct explorer data type"
                 },
                 "link": {
@@ -152,7 +193,10 @@
           },
           "configurationType": {
             "type": "string",
-            "enum": ["mainnet", "testnet"],
+            "enum": [
+              "mainnet",
+              "testnet"
+            ],
             "description": "Must select either mainnet or testnet"
           }
         }


### PR DESCRIPTION
Adds `web3`, `rest`, `jrpc` fields to the chain `configuration` model.

_Needed for permission-less python cronjobs refactor_