### PR TITLE
Corrected USDT for gravity

### DIFF
--- a/tokens/gUSDT.json
+++ b/tokens/gUSDT.json
@@ -12,7 +12,7 @@
   "isEnabled": true,
   "erc20Address": "0xecEEEfCEE421D8062EF8d6b4D814efe4dc898265",
   "ibc": {
-    "sourceDenom": "gravity0x6c9E3E437b0F06C5366fAE4ea4e6cd6fB1803BdF",
+    "sourceDenom": "gravity0xdAC17F958D2ee523a2206206994597C13D831ec7",
     "source": "Gravity"
   },
   "hideFromTestnet": true,


### PR DESCRIPTION
For some reason the value of Gravity USDT is incorrect so it was not querying the right value. I had to go to https://lcd-gravity-bridge.keplr.app/ and check with my Keplr to validate.