### PR TITLE
fix: using Emoney as source denom to match the network identifier

### DIFF
--- a/tokens/EEUR.json
+++ b/tokens/EEUR.json
@@ -13,7 +13,7 @@
   "erc20Address": "0x5db67696C3c088DfBf588d3dd849f44266ff0ffa",
   "ibc": {
     "sourceDenom": "eeur",
-    "source": "e-Money"
+    "source": "Emoney"
   },
   "hideFromTestnet": false,
   "coingeckoId": "e-money-eur",


### PR DESCRIPTION
The source denom should match the network identifier so it's easy to match the token with the network