### PR TITLE
fix: replace sourceDenom for ukuji

### DIFF
--- a/tokens/USK.json
+++ b/tokens/USK.json
@@ -12,7 +12,7 @@
   "isEnabled": true,
   "erc20Address": "0x13974cf36984216C90D1F4FC815C156092feA396",
   "ibc": {
-    "sourceDenom": "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk",
+    "sourceDenom": "ukuji",
     "source": "Kujira"
   },
   "hideFromTestnet": false,


### PR DESCRIPTION
Source denom was set incorrectly and the dashboard was unable to get the balance or sign/broadcast the tx