### PR TITLE
Fix Teritori destination and source channels

### DIFF
--- a/chainConfig/teritori.json
+++ b/chainConfig/teritori.json
@@ -39,9 +39,9 @@
                 }
             ],
             "source": {
-                "sourceChannel": "channel-35",
+                "sourceChannel": "channel-1",
                 "sourceIBCDenomToEvmos": "IBC/18D5C3CDDF1DEE108CE4BF0A7E0262D94D11AB06A37F68EA38F70CC92C5D894F",
-                "destinationChannel": "channel-1",
+                "destinationChannel": "channel-35",
                 "jsonRPC": [
                     "https://rpc.mainnet.teritori.com"
                 ]


### PR DESCRIPTION
Teritori source and destination channels were mixed up.

I also tested every chain and assets to make sure the metadata is correct and I only found issues with Teritori.