### PR TITLE
fix: Required props moved to the right place

### DIFF
--- a/schema.chain.json
+++ b/schema.chain.json
@@ -9,7 +9,6 @@
     "bip44"
   ],
   "properties": {
-
     "prefix": {
       "type": "string",
       "description": "Chain prefix i.e. evmos"

--- a/schema.chain.json
+++ b/schema.chain.json
@@ -3,12 +3,13 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Chain Registry via Evmos Governance",
   "type": "object",
+  "required": [
+    "gasPriceStep",
+    "prefix",
+    "bip44"
+  ],
   "properties": {
-    "required": [
-      "gasPriceStep",
-      "prefix",
-      "bip44"
-    ],
+
     "prefix": {
       "type": "string",
       "description": "Chain prefix i.e. evmos"
@@ -32,12 +33,7 @@
         "high": {
           "type": "string",
           "description": "Amount of gas for High"
-        },
-        "required": [
-          "low",
-          "medium",
-          "high"
-        ]
+        }
       }
     },
     "feeMarket": {
@@ -220,7 +216,7 @@
             ],
             "description": "Must select either mainnet or testnet"
           },
-          "explorerTxUrl": { 
+          "explorerTxUrl": {
             "type": "string",
             "description": "Explorer tx URL for the chain, i.e https://www.mintscan.io/evmos/txs."
           }


### PR DESCRIPTION
- the required field for the "properties" was inside the properties field. 
- gasPriceStep had a duplicate version of the required field inside it

on another note, is the id for this correct?
