### PR TITLE
fix:  source ibc denom to evmos for teritori & comdex

### DIFF
--- a/chainConfig/comdex.json
+++ b/chainConfig/comdex.json
@@ -41,7 +41,7 @@
       ],
       "source": {
         "sourceChannel": "channel-35",
-        "sourceIBCDenomToEvmos": "ibc/61DF64ADF65230540C14C63D64897BE08A3DC9A516A91425913F01240E2F432F",
+        "sourceIBCDenomToEvmos": "ibc/D01562AB9C4CC84E06A84FFA213C7592508120C3F91EFFB1E62117D5932C2B1F",
         "destinationChannel": "channel-26",
         "jsonRPC": ["https://rpc.comdex.one"]
       },

--- a/chainConfig/teritori.json
+++ b/chainConfig/teritori.json
@@ -40,7 +40,7 @@
             ],
             "source": {
                 "sourceChannel": "channel-1",
-                "sourceIBCDenomToEvmos": "IBC/18D5C3CDDF1DEE108CE4BF0A7E0262D94D11AB06A37F68EA38F70CC92C5D894F",
+                "sourceIBCDenomToEvmos": "ibc/6993F2B27985C9363D3B94D702111940055833A2BA86DA93F33A67D03E4D1B7D",
                 "destinationChannel": "channel-35",
                 "jsonRPC": [
                     "https://rpc.mainnet.teritori.com"


### PR DESCRIPTION
Using the unique channel that exists, I sent EVMOS from teritori to EVMOS and the sourceIBCDenomToEvmos was different in mintscan. The same case was for Comdex

Example Teritori: https://www.mintscan.io/teritori/account/tori1j30xhsxcqss0n662wrma0vqw4zcx285mkuc22l
Example [Comdex](https://www.mintscan.io/comdex/account/comdex1j30xhsxcqss0n662wrma0vqw4zcx285mn8dpgc): 
Updated the sourceIBCDenomToEvmos for Teritori and Comdex