### PR TITLE
chore: Update stINJ.json to use 18 decimals

### DIFF
--- a/tokens/stINJ.json
+++ b/tokens/stINJ.json
@@ -4,7 +4,7 @@
   "imgSrc": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stinj.svg",
   "pngSrc": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stinj.png",
   "type": "IBC",
-  "exponent": "6",
+  "exponent": "18",
   "cosmosDenom": "ibc/4FCDD6D71CAB4F6BBEAB781D036977E1158075297671345055BC342D46819640",
   "description": "Staking derivative by Stride",
   "name": "Stride Staked Inj",


### PR DESCRIPTION
This PR simply updated the stINJ.json token config to use 18 decimals instead of 6