### PR TITLE
Add metadata for TASHI token

### DIFF
--- a/tokens/TASHI.json
+++ b/tokens/TASHI.json
@@ -1,0 +1,23 @@
+{
+  "coinDenom": "TASHI",
+  "minCoinDenom": "tashi",
+  "imgSrc": "https://app.tashi.finance/svgs/tashi-icon.svg",
+  "pngSrc": "https://app.tashi.finance/svgs/tashi-icon.svg",
+  "type": "IBC",
+  "exponent": "18",
+  "cosmosDenom": "erc20/0x98fAFD9F714CE0B4bB2870527076F2F314aAed82",
+  "description": "Tashi",
+  "name": "Tashi",
+  "tokenRepresentation": "TASHI",
+  "channel": "",
+  "isEnabled": true,
+  "erc20Address": "0x98fAFD9F714CE0B4bB2870527076F2F314aAed82",
+  "ibc": {
+    "sourceDenom": "tashi",
+    "source": "Evmos"
+  },
+  "hideFromTestnet": false,
+  "coingeckoId": "",
+  "category": "cosmos",
+  "coinSourcePrefix": "evmos"
+}


### PR DESCRIPTION
The proposal to register the Tashi ERC20 as an IBC coin recently passed: https://www.mintscan.io/evmos/proposals/174

This PR is to add the metadata of Tashi token.