### PR TITLE
chore: capitalize network names

### DIFF
--- a/chainConfig/crescent.json
+++ b/chainConfig/crescent.json
@@ -11,7 +11,7 @@
     "configurations": [
       {
         "chainId": "crescent-1",
-        "chainName": "Crescent NetWork",
+        "chainName": "Crescent Network",
         "identifier": "Crescent",
         "clientId": "07-tendermint-38",
         "rest": [

--- a/chainConfig/kava.json
+++ b/chainConfig/kava.json
@@ -11,7 +11,7 @@
     "configurations": [
       {
         "chainId": "kava_2222-10",
-        "chainName": "kava",
+        "chainName": "Kava",
         "identifier": "Kava",
         "clientId": "07-tendermint-113",
         "rest": [

--- a/chainConfig/quicksilver.json
+++ b/chainConfig/quicksilver.json
@@ -11,7 +11,7 @@
   "configurations": [
     {
       "chainId": "quicksilver-2",
-      "chainName": "quicksilver",
+      "chainName": "Quicksilver",
       "identifier": "Quicksilver",
       "rpc": [
         "https://quicksilver-rpc.polkachu.com:443"

--- a/chainConfig/stride.json
+++ b/chainConfig/stride.json
@@ -11,7 +11,7 @@
   "configurations": [
     {
       "chainId": "stride-1",
-      "chainName": "stride",
+      "chainName": "Stride",
       "identifier": "Stride",
       "rpc": [
         "https://stride-rpc.polkachu.com:443"

--- a/chainConfig/teritori.json
+++ b/chainConfig/teritori.json
@@ -11,7 +11,7 @@
     "configurations": [
         {
             "chainId": "teritori-1",
-            "chainName": "teritori",
+            "chainName": "Teritori",
             "identifier": "Teritori",
             "clientId": "07-tendermint-89",
             "rest": [


### PR DESCRIPTION
This PR adds the following changes:


Capitalize the 1st letter of:

stride

teritori

quicksilver


and replace "Crescent NetWork" with "Crescent Network"