### PR TITLE
chore: explorer url for evmos

### DIFF
--- a/chainConfig/evmos.json
+++ b/chainConfig/evmos.json
@@ -69,7 +69,7 @@
         }
       ],
       "configurationType": "mainnet",
-      "explorerTxUrl": "https://www.mintscan.io/evmos/txs"
+      "explorerTxUrl": "https://escan.live/tx"
     }
   ]
 }


### PR DESCRIPTION
This PR links out the evmos txns to escan instead of minstcan.