### PR TITLE
fix: conflicting token names

### DIFF
--- a/tokens/USDC.grv.json
+++ b/tokens/USDC.grv.json
@@ -7,7 +7,7 @@
   "exponent": "6",
   "cosmosDenom": "ibc/693989F95CF3279ADC113A6EF21B02A51EC054C95A9083F2E290126668149433",
   "description": "USD Coin via Gravity Bridge",
-  "name": "USD Coin",
+  "name": "USD Coin - Gravity",
   "tokenRepresentation": "USDC",
   "channel": "channel-8",
   "isEnabled": true,


### PR DESCRIPTION
Forge Assets page when trying to deposit Noble USDC generates the following payload:

```
{
  "account_number": "nnnn",
  "chain_id": "noble-1",
  "fee": {
    "gas": "300000",
    "amount": [
      {
        "amount": "0",
        "denom": "uusdc"
      }
    ]
  },
  "memo": "",
  "msgs": [
    {
      "type": "cosmos-sdk/MsgTransfer",
      "value": {
        "receiver": "evmos1xxx",
        "sender": "noble1fxxx",
        "source_channel": "channel-7",
        "source_port": "transfer",
        "timeout_height": {
          "revision_height": "16865337",
          "revision_number": "2"
        },
        "timeout_timestamp": "1698941235289511273",
        "token": {
          "amount": "187913",
          "denom": "gravity0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
        }
      }
    }
  ],
  "sequence": "3"
}

```

Seeing if the conflicting token name fixes the incorrect denom