### PR TITLE
update: explorer tx url for evmos

### DIFF
--- a/chainConfig/evmos.json
+++ b/chainConfig/evmos.json
@@ -67,7 +67,7 @@
         }
       ],
       "configurationType": "mainnet",
-      "explorerTxUrl": "https://escan.live/tx",
+      "explorerTxUrl": "https://www.mintscan.io/evmos/tx",
       "img": {
         "svg": "https://raw.githubusercontent.com/evmos/chain-token-registry/main/assets/chainConfig/evmos.svg",
         "png": "https://raw.githubusercontent.com/evmos/chain-token-registry/main/assets/chainConfig/evmos.png"


### PR DESCRIPTION
Update explorer url for evmos. Use mintscan instead of escan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the transaction explorer URL for the Evmos blockchain to enhance user experience and tracking capabilities.
  
- **Bug Fixes**
	- Resolved discrepancies in the transaction tracking service by switching to a more reliable URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->